### PR TITLE
Precalculate Synth period from sample_rate

### DIFF
--- a/src/server/audio/mod.rs
+++ b/src/server/audio/mod.rs
@@ -31,9 +31,9 @@ pub fn run(receiver: Receiver<Event>) {
 
 	event_loop.play_stream(stream_id.clone()).unwrap();
 
-	let sample_rate = format.sample_rate.0 as f64;
+	let period = 1.0 / f64::from(format.sample_rate.0);
 
-	let mut engine = Engine::new(sample_rate);
+	let mut engine = Engine::new(period);
 
 	let event_loop_ref = &event_loop;
 	event_loop.run(move |id, result| {
@@ -73,7 +73,6 @@ mod synth;
 use synth::Synth;
 
 struct Engine {
-	sample_rate: f64,
 	sheet: Sheet,
 	cursor: f64,
 	active: bool,
@@ -82,13 +81,12 @@ struct Engine {
 }
 
 impl Engine {
-	pub fn new(sample_rate: f64) -> Engine {
+	pub fn new(period: f64) -> Engine {
 		Engine {
-			sample_rate,
 			sheet: Sheet::default(),
 			cursor: 0.0,
 			active: false,
-			synth: Synth::new(sample_rate),
+			synth: Synth::new(period),
 			tempo: 140.0,
 		}
 	}
@@ -120,7 +118,7 @@ impl Engine {
 
 	pub fn update(&mut self, samples: usize) {
 		if self.active {
-			let length = samples as f64 / self.sample_rate * (self.tempo / 60.0);
+			let length = samples as f64 * self.synth.period * (self.tempo / 60.0);
 			let range = Range(self.cursor, self.cursor + length);
 			self.cursor += length;
 			let mut events = self.sheet.get_events(range);

--- a/src/server/audio/synth.rs
+++ b/src/server/audio/synth.rs
@@ -38,16 +38,16 @@ impl Voice {
 }
 
 pub struct Synth {
-	sample_rate: f64,
+	pub period: f64,
 	voices: Vec<Voice>,
 	lowpass: svf::Kernel,
 	limiter: Limiter,
 }
 
 impl Synth {
-	pub fn new(sample_rate: f64) -> Synth {
+	pub fn new(period: f64) -> Synth {
 		Synth {
-			sample_rate,
+			period,
 			voices: vec![],
 			lowpass: svf::lowpass(0.02, 0.3),
 			limiter: Limiter::new(),
@@ -89,7 +89,7 @@ impl Synth {
 		let mut out = 0.0;
 
 		for voice in &mut self.voices {
-			out += voice.next(1.0 / self.sample_rate);
+			out += voice.next(self.period);
 		}
 
 		self.voices.retain(|voice| voice.adsr.state != adsr::Dead);


### PR DESCRIPTION
Precalculate `period` from `sample_rate` as early as possible, so that we don't need to re-calculate it in every invocation of `Synth::next_sample()`